### PR TITLE
Update addasl to use imm_5_7u

### DIFF
--- a/Hexagon/data/languages/xtype_shift.sinc
+++ b/Hexagon/data/languages/xtype_shift.sinc
@@ -127,8 +127,8 @@ with slot: iclass=0b1101  {
 
 #XTYPE/SHIFT:Shift by imm and add
 with slot: iclass=0b1100  {
-    :D5"=addasl("T5","S5"<<"imm_5_7")" is imm_21_27=0b0100000 & S5 & S5i & imm_13=0 & T5 & T5i & imm_5_7 & D5 & OUTPUT_D5 {
-        D5 = T5i + (S5i << imm_5_7);
+    :D5"=addasl("T5","S5"<<"imm_5_7u")" is imm_21_27=0b0100000 & S5 & S5i & imm_13=0 & T5 & T5i & imm_5_7u & D5 & OUTPUT_D5 {
+        D5 = T5i + (S5i << imm_5_7u);
     }
 }
 


### PR DESCRIPTION
The instruction used a signed version instead of unsigned, resulting in instructions that both looked wrong and generated incorrect pcode. For example `r5=addasl(r5,r6<<#-0x4)` with bad pcode `$U84b00:4 = INT_LEFT r6c, 0xfffffffc:4` would then get optimized by the decompiler as being 0 for for the shift and not use `r6` at all