### PR TITLE
Remove erroneous shift

### DIFF
--- a/Hexagon/data/languages/st_byte.sinc
+++ b/Hexagon/data/languages/st_byte.sinc
@@ -47,12 +47,12 @@ with slot: iclass=0b1010  {
         *[ram]:1 EA = T5_pairi:1;
         S5 = EA;
      }
-    :"memb(" S5 "++" s4 ")=" T5 is imm_21_27=0b1011000 & S5 & S5i & imm_13=0 & T5 & T5i & imm_7=0 & imm_3_6 & imm_2=0 & imm_1=0 & imm_0=0  [s4 = imm_3_6 << 2;] {
+    :"memb(" S5 "++" s4 ")=" T5 is imm_21_27=0b1011000 & S5 & S5i & imm_13=0 & T5 & T5i & imm_7=0 & imm_3_6 & imm_2=0 & imm_1=0 & imm_0=0  [s4 = imm_3_6 << 0;] {
         local EA:4 = S5i;
         S5 = S5i+s4;
         *[ram]:1 EA = T5i;
     }
-    :"memb(" S5 "++" s4 "):nt =" T5 is imm_21_27=0b1010000 & S5 & S5i & imm_13=0 & T5 & T5i & imm_7=0 & imm_3_6 & imm_2=0 & imm_1=0 & imm_0=0  [s4 = imm_3_6 << 2;] {
+    :"memb(" S5 "++" s4 "):nt =" T5 is imm_21_27=0b1010000 & S5 & S5i & imm_13=0 & T5 & T5i & imm_7=0 & imm_3_6 & imm_2=0 & imm_1=0 & imm_0=0  [s4 = imm_3_6 << 0;] {
         local EA:4 = S5i;
         S5 = S5i+s4;
         *[ram]:1 EA = T5i;


### PR DESCRIPTION
`memb` instruction should not be multiplying the offset by 4, but leaving it as is for 1 byte alignment