### PR TITLE
Fix halfword store encoding

### DIFF
--- a/Hexagon/data/languages/st_halfword.sinc
+++ b/Hexagon/data/languages/st_halfword.sinc
@@ -403,33 +403,29 @@ BR_ST_HW_COND_2_u6: u6 is imm_3_6u & imm_16_17u & immext0pos=pktid & immext0 [u6
 NR_ST_HW_COND_2_u6: u6 is imm_3_6u & imm_16_17u & IS_EXT1 & immext1 [u6 = (imm_3_6u | (imm_16_17u << 4)) | immext1; immext1pos=pktid;] { export *[const]:4 u6; }
 BR_ST_HW_COND_2_u6: u6 is imm_3_6u & imm_16_17u & immext1pos=pktid & immext1 [u6 = (imm_3_6u | (imm_16_17u << 4)) | immext1; ] { export *[const]:4 u6; }
 
-    :"if(" D2_pred ") memh(" NR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_11_13=0b010 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=0 & D2_pred & D2_predi  & NR_ST_HW_COND_2_u6 {
+    :"if(" D2_pred ") memh(" NR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_13=0 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=0 & D2_pred & D2_predi  & NR_ST_HW_COND_2_u6 {
         if(D2_predi == 0) goto <end>;
             local EA:4 = NR_ST_HW_COND_2_u6;
             *[ram]:2 EA = T5i:2;
         <end>
     }
-    :"if(!" D2_pred ") memh(" NR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_11_13=0b110 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=0 & D2_pred & D2_predi  & NR_ST_HW_COND_2_u6 {
+    :"if(!" D2_pred ") memh(" NR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_13=0 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred & D2_predi  & NR_ST_HW_COND_2_u6 {
         if(D2_predi != 0) goto <end>;
             local EA:4 = NR_ST_HW_COND_2_u6;
             *[ram]:2 EA = T5i:2;
         <end>
     }
-    :"if(" D2_pred_new ".new) memh(" NR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_11_13=0b010 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new  & NR_ST_HW_COND_2_u6 {}
+    :"if(" D2_pred_new ".new) memh(" NR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_13=1 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=0 & D2_pred_new  & NR_ST_HW_COND_2_u6 {}
+    :"if(!" D2_pred_new ".new) memh(" NR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_13=1 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new  & NR_ST_HW_COND_2_u6 {}
 }
 with slotNV: iclass=0b1010 {
-    :"if(" D2_pred_new ".new) memh(" BR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_11_13=0b010 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new & BR_ST_HW_COND_2_u6 {
+    :"if(" D2_pred_new ".new) memh(" BR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_13=1 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=0 & D2_pred_new & BR_ST_HW_COND_2_u6 {
         if(D2_pred_new == 0) goto <end>;
             local EA:4 = BR_ST_HW_COND_2_u6;
             *[ram]:2 EA = T5i:2;
         <end>
     }
-}
-with slot: iclass=0b1010 {
-    :"if(!" D2_pred_new ".new) memh(" NR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_11_13=0b110 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new  & NR_ST_HW_COND_2_u6 {}
-}
-with slotNV: iclass=0b1010 {
-    :"if(!" D2_pred_new ".new) memh(" BR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_11_13=0b110 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new & BR_ST_HW_COND_2_u6 {
+    :"if(!" D2_pred_new ".new) memh(" BR_ST_HW_COND_2_u6 ")=" T5 is imm_21_27=0b1111010 & imm_18_20=0 & imm_16_17u & imm_13=1 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new & BR_ST_HW_COND_2_u6 {
         if(D2_pred_new != 0) goto <end>;
             local EA:4 = BR_ST_HW_COND_2_u6;
             *[ram]:2 EA = T5i:2;
@@ -437,33 +433,29 @@ with slotNV: iclass=0b1010 {
     }
 }
  with slot: iclass=0b1010 {   
-    :"if(" D2_pred ") memh(" NR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_11_13=0b010 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=0 & D2_pred & D2_predi  & NR_ST_HW_COND_2_u6 {
+    :"if(" D2_pred ") memh(" NR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_13=0 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=0 & D2_pred & D2_predi  & NR_ST_HW_COND_2_u6 {
         if(D2_predi == 0) goto <end>;
             local EA:4 = NR_ST_HW_COND_2_u6;
             *[ram]:2 EA = T5i(2);
         <end>
     }
-    :"if(!" D2_pred ") memh(" NR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_11_13=0b110 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=0 & D2_pred & D2_predi  & NR_ST_HW_COND_2_u6 {
+    :"if(!" D2_pred ") memh(" NR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_13=0 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred & D2_predi  & NR_ST_HW_COND_2_u6 {
         if(D2_predi != 0) goto <end>;
             local EA:4 = NR_ST_HW_COND_2_u6;
             *[ram]:2 EA = T5i(2);
         <end>
     }
-    :"if(" D2_pred_new ".new) memh(" NR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_11_13=0b010 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new  & NR_ST_HW_COND_2_u6 {}
+    :"if(" D2_pred_new ".new) memh(" NR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_13=1 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=0 & D2_pred_new  & NR_ST_HW_COND_2_u6 {}
+    :"if(!" D2_pred_new ".new) memh(" NR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_13=1 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new  & NR_ST_HW_COND_2_u6 {}
 }
 with slotNV: iclass=0b1010 {
-    :"if(" D2_pred_new ".new) memh(" BR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_11_13=0b010 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new & BR_ST_HW_COND_2_u6 {
+    :"if(" D2_pred_new ".new) memh(" BR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_13=1 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=0 & D2_pred_new & BR_ST_HW_COND_2_u6 {
         if(D2_pred_new == 0) goto <end>;
             local EA:4 = BR_ST_HW_COND_2_u6;
             *[ram]:2 EA = T5i(2);
         <end>
     }
-}
-with slot: iclass=0b1010 {
-    :"if(!" D2_pred_new ".new) memh(" NR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_11_13=0b110 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new  & NR_ST_HW_COND_2_u6 {}
-}
-with slotNV: iclass=0b1010 {
-    :"if(!" D2_pred_new ".new) memh(" BR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_11_13=0b110 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new & BR_ST_HW_COND_2_u6 {
+    :"if(!" D2_pred_new ".new) memh(" BR_ST_HW_COND_2_u6 ")=" T5".H" is imm_21_27=0b1111011 & imm_18_20=0 & imm_16_17u & imm_13=1 & T5 & T5i & imm_7=1 & imm_3_6u & imm_2=1 & D2_pred_new & BR_ST_HW_COND_2_u6 {
         if(D2_pred_new != 0) goto <end>;
             local EA:4 = BR_ST_HW_COND_2_u6;
             *[ram]:2 EA = T5i(2);


### PR DESCRIPTION
The decoding for these instructions did not match the specification, resulting in either failure to disassemble entirely or in some cases mapping to wrong operation