### PR TITLE
Add pcode for boundscheck

### DIFF
--- a/Hexagon/data/languages/xtype_pred.sinc
+++ b/Hexagon/data/languages/xtype_pred.sinc
@@ -1,13 +1,35 @@
 # XTYPE/PRED
 # XTYPE/PRED:bound chk
-define pcodeop boundscheck_raw_lo;
-define pcodeop boundscheck_raw_hi;
 with slot: iclass=0b1101  {
     :D2_pred "=boundscheck(" S5_pair "," T5_pair "):raw:lo" is imm_23_27=0b00100 & imm_21_22=0 & S5_pair & S5_pairi & imm_13=1 & T5_pair & T5_pairi & imm_5_7=0b100 & imm_2_4=0 & D2_pred {
-        D2_pred = boundscheck_raw_lo(S5_pairi, T5_pairi);
+        local tmp:4 = &S5_pairi;
+        local src:4 = *[register]:4 tmp;
+        local tmp2:4 = &T5_pairi;
+        local lo:4 = *[register]:4 tmp2;
+        tmp2 = tmp2 + 4;
+        local hi:4 = *[register]:4 tmp2;
+
+        if (src >= lo && src < hi) goto <good>;
+        D2_pred = 0;
+        goto <end>;
+        <good>
+        D2_pred = PTRUE;
+        <end>
     }
     :D2_pred "=boundscheck(" S5_pair "," T5_pair "):raw:hi" is imm_23_27=0b00100 & imm_21_22=0 & S5_pair & S5_pairi & imm_13=1 & T5_pair & T5_pairi & imm_5_7=0b101 & imm_2_4=0 & D2_pred {
-        D2_pred = boundscheck_raw_hi(S5_pairi, T5_pairi);
+        local tmp:4 = &S5_pairi + 4;
+        local src:4 = *[register]:4 tmp;
+        local tmp2:4 = &T5_pairi;
+        local lo:4 = *[register]:4 tmp2;
+        tmp2 = tmp2 + 4;
+        local hi:4 = *[register]:4 tmp2;
+
+        if (src >= lo && src < hi) goto <good>;
+        D2_pred = 0;
+        goto <end>;
+        <good>
+        D2_pred = PTRUE;
+        <end>
     }
 }
 


### PR DESCRIPTION
There's probably a better way to write this pcode, but here's a take at is for `boundscheck`.  This instruction takes pairs, but operates on the 32-bit registers, so dividing into separate accesses really helps the decompilation.

Example disassembly:
<img width="1261" height="249" alt="image" src="https://github.com/user-attachments/assets/7bde3257-8abc-4d80-b788-6cf6a5eccdbe" />

Function decompiled with this pcode:
<img width="566" height="734" alt="image" src="https://github.com/user-attachments/assets/abad6b71-4505-4dbe-8545-0c2dba327df0" />
