### PR TITLE
Fix copy paste error in togglebit name

### DIFF
--- a/Hexagon/data/languages/xtype_bit.sinc
+++ b/Hexagon/data/languages/xtype_bit.sinc
@@ -178,7 +178,7 @@ with slot: iclass=0b1000  {
     :D5"=clrbit("S5","imm_8_12u")" is imm_21_27=0b1100110 & S5 & S5i & imm_13=0 & imm_8_12u & imm_5_7=0b001 & D5 & OUTPUT_D5 {
        D5 = S5i & ~(1 << imm_8_12u);
     }
-    :D5"=clrbit("S5","imm_8_12u")" is imm_21_27=0b1100110 & S5 & S5i & imm_13=0 & imm_8_12u & imm_5_7=0b010 & D5 & OUTPUT_D5 {
+    :D5"=togglebit("S5","imm_8_12u")" is imm_21_27=0b1100110 & S5 & S5i & imm_13=0 & imm_8_12u & imm_5_7=0b010 & D5 & OUTPUT_D5 {
        D5 = S5i ^ (1 << imm_8_12u);
     }
 }


### PR DESCRIPTION
The pcode was correct, but `togglebit` was incorrectly disassembled with the name `clrbit`